### PR TITLE
Fix: Revert to genai.protos for speech configuration objects

### DIFF
--- a/app.py
+++ b/app.py
@@ -29,19 +29,19 @@ def generate_audio():
     try:
         model = genai.GenerativeModel(model_name="gemini-2.5-flash-preview-tts")
         
-        # Using direct genai module attributes for speech and generation configuration.
+        # Using genai.protos for speech-related configuration objects.
         
-        # Define the speech configuration using direct genai attributes
-        speech_config = genai.SpeechConfig(
-            voice_config=genai.VoiceConfig(
-                prebuilt_voice_config=genai.PrebuiltVoiceConfig(
+        # Define the speech configuration using genai.protos
+        speech_config = genai.protos.SpeechConfig(
+            voice_config=genai.protos.VoiceConfig(
+                prebuilt_voice_config=genai.protos.PrebuiltVoiceConfig(
                     voice_name=voice_name_to_use
                 )
             )
         )
 
         # Define the main generation configuration including speech_config and response_modalities
-        # Using direct genai attributes.
+        # genai.GenerationConfig is used directly, while speech_config is a proto object.
         generation_config = genai.GenerationConfig(
             response_modalities=["AUDIO"],
             speech_config=speech_config


### PR DESCRIPTION
I've reverted the instantiation of speech-related configuration objects (`SpeechConfig`, `VoiceConfig`, `PrebuiltVoiceConfig`) in `app.py` to use the `genai.protos` namespace (e.g., `genai.protos.SpeechConfig`).

This change aims to resolve the persistent `AttributeError` you encountered with `google-generativeai==0.8.5` when trying to use `genai.types.SpeechConfig` or `genai.SpeechConfig`.

The main `generation_config` object passed to `model.generate_content()` continues to be an instance of `genai.GenerationConfig`, now containing the proto-based `speech_config` and `response_modalities=["AUDIO"]`.

I've verified that `tests/test_app.py` is compatible with this structure as it asserts on the attributes of the passed config objects, not their specific class types beyond that. `requirements.txt` remains `google-generativeai>=0.6.0`.