### PR TITLE
Fix test comment about missing API key

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -82,7 +82,7 @@ def test_generate_audio_no_text(client):
 def test_generate_audio_no_api_key(client):
     '''Test audio generation with no API key set.'''
     response = client.post('/generate-audio', json={"text": "Hello"})
-    assert response.status_code == 500 # Or 401 if you made that change
+    assert response.status_code == 500 # Response should be 500 when GEMINI_API_KEY is not set
     assert response.json == {"error": "GEMINI_API_KEY not set"}
     
 @patch('app.genai.GenerativeModel')


### PR DESCRIPTION
## Summary
- clarify the expected status code when `GEMINI_API_KEY` isn't set

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684338af916c832dbf6d5b82e3e2a640