### PR TITLE
Improve error handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ import google.generativeai as genai
 # Removed: from google.generativeai import types
 import wave
 import io
+from werkzeug.exceptions import HTTPException
 
 app = Flask(__name__)
 
@@ -84,6 +85,18 @@ def generate_audio():
         return jsonify({"error": f"Failed to process audio data: {str(e)}"}), 500
 
     return send_file(wav_buffer, mimetype='audio/wav')
+
+
+@app.errorhandler(Exception)
+def handle_unexpected_error(e):
+    """Return JSON for any unhandled server errors."""
+    if isinstance(e, HTTPException):
+        code = e.code
+        description = e.description
+    else:
+        code = 500
+        description = str(e)
+    return jsonify({"error": f"Unexpected server error: {description}"}), code
 
 if __name__ == '__main__':
     # Note: For production, use a proper WSGI server.

--- a/static/script.js
+++ b/static/script.js
@@ -50,15 +50,20 @@ document.addEventListener('DOMContentLoaded', () => {
         .then(response => {
             if (response.ok) {
                 return response.blob();
-            } else {
-                // Try to parse JSON error response from backend
-                return response.json().then(err => {
-                    throw new Error(err.error || `Server error: ${response.status}`);
-                }).catch(parseError => {
-                    // Fallback if parsing JSON fails or it's not a JSON error
+            }
+            // Try to parse JSON error response from backend first
+            return response.clone().json().then(err => {
+                throw new Error(err.error || err.message || `Server error: ${response.status}`);
+            }).catch(() => {
+                // Fallback: attempt to read plain text from the response
+                return response.text().then(text => {
+                    const msg = text.trim();
+                    if (msg) {
+                        throw new Error(msg);
+                    }
                     throw new Error(`Server error: ${response.status}. Could not parse error details.`);
                 });
-            }
+            });
         })
         .then(blob => {
             const audioUrl = URL.createObjectURL(blob);

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -138,3 +138,22 @@ def test_generate_audio_default_voice(mock_generative_model, client):
     args, kwargs = mock_model_instance.generate_content.call_args
     generation_config_arg = kwargs['generation_config']
     assert generation_config_arg.speech_config.voice_config.prebuilt_voice_config.voice_name == "Kore"
+
+
+@patch('app.send_file', side_effect=Exception("Send file error"))
+@patch('app.genai.GenerativeModel')
+@patch.dict(os.environ, {"GEMINI_API_KEY": "test_api_key"})
+def test_generate_audio_unhandled_exception(mock_generative_model, mock_send_file, client):
+    '''Ensure unhandled exceptions return JSON error responses.'''
+    mock_model_instance = MagicMock()
+    mock_response = MagicMock()
+    mock_part = MagicMock()
+    mock_part.inline_data.data = b"dummy_pcm_audio_data"
+    mock_response.candidates = [MagicMock(content=MagicMock(parts=[mock_part]))]
+    mock_model_instance.generate_content.return_value = mock_response
+    mock_generative_model.return_value = mock_model_instance
+
+    response = client.post('/generate-audio', json={"text": "Hello"})
+
+    assert response.status_code == 500
+    assert response.json["error"].startswith("Unexpected server error: Send file error")


### PR DESCRIPTION
## Summary
- show server error details to the user
- return JSON from the server for unhandled exceptions
- add regression tests for unhandled 500 errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68433ca2e34c832da50b6cf267f205f2