### PR TITLE
Fix TTS mime type

### DIFF
--- a/app.py
+++ b/app.py
@@ -43,9 +43,7 @@ def generate_audio():
 
         # Define the main generation configuration including speech_config and desired response MIME type
         # genai.GenerationConfig is used directly, while speech_config is a proto object.
-        generation_config = genai.GenerationConfig(
-            response_mime_type="audio/wav"
-        )
+        generation_config = genai.GenerationConfig()
         # Attach the speech configuration as an attribute so tests can inspect it
         generation_config.speech_config = speech_config
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -67,7 +67,7 @@ def test_generate_audio_success(mock_generative_model, client):
     assert kwargs['contents'] == ["Hello world"]
     # Check the arguments passed to generate_content, aligning with app.py's current structure
     generation_config_arg = kwargs['generation_config']
-    assert generation_config_arg.response_mime_type == "audio/wav"
+    assert generation_config_arg.response_mime_type is None
     assert generation_config_arg.speech_config.voice_config.prebuilt_voice_config.voice_name == "Kore"
 
 
@@ -118,7 +118,7 @@ def test_generate_audio_specific_voice(mock_generative_model, client):
     args, kwargs = mock_model_instance.generate_content.call_args
     # Check the arguments passed to generate_content for the specific voice
     generation_config_arg = kwargs['generation_config']
-    assert generation_config_arg.response_mime_type == "audio/wav"  # Should still be present
+    assert generation_config_arg.response_mime_type is None  # Should be unset
     assert generation_config_arg.speech_config.voice_config.prebuilt_voice_config.voice_name == "Puck"
 
 @patch('app.genai.GenerativeModel')


### PR DESCRIPTION
## Summary
- fix GenerationConfig to omit invalid response mime type
- adjust unit tests for new default

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68433e4edaf0832d87dac0aa72d0d07e