### PR TITLE
Add streaming audio tests and endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, render_template, request, jsonify, send_file
+from flask import Flask, render_template, request, jsonify, send_file, Response
 import os
 from google import genai
 import wave
@@ -76,6 +76,61 @@ def generate_audio():
         return jsonify({"error": f"Failed to process audio data: {str(e)}"}), 500
 
     return send_file(wav_buffer, mimetype='audio/wav')
+
+
+@app.route('/stream-audio', methods=['POST'])
+def stream_audio():
+    api_key = os.environ.get("GEMINI_API_KEY")
+    if not api_key:
+        return jsonify({"error": "GEMINI_API_KEY not set"}), 500
+
+    data = request.get_json()
+    text_to_synthesize = data.get('text') if data else None
+    voice_name_to_use = data.get('voice_name', 'Kore') if data else 'Kore'
+
+    if not text_to_synthesize:
+        return jsonify({"error": "No text provided"}), 400
+
+    client = genai.Client(api_key=api_key)
+
+    try:
+        config = genai.types.GenerateContentConfig(
+            response_modalities=["AUDIO"],
+            speech_config=genai.types.SpeechConfig(
+                voice_config=genai.types.VoiceConfig(
+                    prebuilt_voice_config=genai.types.PrebuiltVoiceConfig(
+                        voice_name=voice_name_to_use
+                    )
+                )
+            ),
+        )
+
+        stream = client.models.generate_content_stream(
+            model="gemini-2.5-flash-preview-tts",
+            contents=text_to_synthesize,
+            config=config,
+        )
+
+        audio_chunks = []
+        for chunk in stream:
+            if (
+                chunk.candidates
+                and chunk.candidates[0].content
+                and chunk.candidates[0].content.parts
+            ):
+                part = chunk.candidates[0].content.parts[0]
+                if part.inline_data and part.inline_data.data:
+                    audio_chunks.append(part.inline_data.data)
+
+        audio_data_pcm = b"".join(audio_chunks)
+
+    except Exception as e:
+        print(f"Error during Gemini API stream: {e}")
+        if "API key not valid" in str(e) or "PERMISSION_DENIED" in str(e):
+            return jsonify({"error": f"TTS generation failed: Invalid API Key or insufficient permissions. Details: {str(e)}"}), 401
+        return jsonify({"error": f"TTS generation failed: {str(e)}"}), 500
+
+    return Response(audio_data_pcm, mimetype='application/octet-stream')
 
 
 @app.errorhandler(Exception)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -158,3 +158,46 @@ def test_generate_audio_unhandled_exception(mock_client_class, mock_send_file, c
 
     assert response.status_code == 500
     assert response.json["error"].startswith("Unexpected server error: Send file error")
+
+
+@patch('app.genai.Client')
+@patch.dict(os.environ, {"GEMINI_API_KEY": "test_api_key"})
+def test_stream_audio_success(mock_client_class, client):
+    '''Test streaming audio returns concatenated PCM data.'''
+    mock_client_instance = MagicMock()
+
+    def generator():
+        chunk1 = MagicMock()
+        part1 = MagicMock()
+        part1.inline_data.data = b"chunk1"
+        chunk1.candidates = [MagicMock(content=MagicMock(parts=[part1]))]
+        chunk2 = MagicMock()
+        part2 = MagicMock()
+        part2.inline_data.data = b"chunk2"
+        chunk2.candidates = [MagicMock(content=MagicMock(parts=[part2]))]
+        yield chunk1
+        yield chunk2
+
+    mock_client_instance.models.generate_content_stream.return_value = generator()
+    mock_client_class.return_value = mock_client_instance
+
+    response = client.post('/stream-audio', json={"text": "Hello"})
+
+    assert response.status_code == 200
+    assert response.data == b"chunk1chunk2"
+
+
+@patch.dict(os.environ, {"GEMINI_API_KEY": "test_api_key"})
+def test_stream_audio_no_text(client):
+    '''Streaming audio should return 400 when no text provided.'''
+    response = client.post('/stream-audio', json={})
+    assert response.status_code == 400
+    assert response.json == {"error": "No text provided"}
+
+
+@patch.dict(os.environ, {}, clear=True)
+def test_stream_audio_no_api_key(client):
+    '''Streaming audio should return 500 when API key missing.'''
+    response = client.post('/stream-audio', json={"text": "Hi"})
+    assert response.status_code == 500
+    assert response.json == {"error": "GEMINI_API_KEY not set"}


### PR DESCRIPTION
## Summary
- add `/stream-audio` endpoint that streams PCM data
- include new unit tests for streaming audio
- update imports for `Response`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843532b844c832da28565215b31a775